### PR TITLE
Fix non-blocking run of puppet

### DIFF
--- a/files/launch-puppet.sh
+++ b/files/launch-puppet.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/opt/puppetlabs/bin/puppet agent -t --logdest /root/puppet.log
+
+if [[ "$?" != 2 ]]; then
+  /opt/puppetlabs/bin/puppet agent -t --logdest /root/puppet.log
+fi 
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,9 +68,19 @@
     - puppet_run_result.rc != 2
     - puppet_run_result.rc != 6
 
+- name: Copy Puppet Running Script (Non-Blocking)
+  copy: 
+    src="launch-puppet.sh"
+    dest="/root/launch-puppet.sh"
+    mode="0700"
+  when: 
+    - puppet_agent_fire_and_forget
+    - puppet_lock_stat.stat.exists == false
+
 - name: Run Puppet (Non-Blocking)
-  command: >
-    /opt/puppetlabs/bin/puppet agent -t --logdest /root/puppet.log &
+  command: /root/launch-puppet.sh
+  async: 2592000
+  poll: 0
   when: 
     - puppet_agent_fire_and_forget
     - puppet_lock_stat.stat.exists == false


### PR DESCRIPTION
I'm using the async option with poll: 0 to trigger the non-blocking puppet run.  "async" can't handle the puppet retry that is required on initial install, and the script: module can't be used with async (because it doesn't use python on the server side, and python is required for the async business), so the compromise is to use copy: + command: module, which does work with async.