### PR TITLE
NSD-2801 ignore errors on puppet run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
   retries: 1
   until: puppet_run_result.rc == 2 or puppet_run_result.rc == 0
   ignore_errors: true
+  failed_when: false ## temporary fix until upstream Interworx bug is in a release
   when:
     - not puppet_agent_fire_and_forget
     - puppet_lock_stat.stat.exists == false


### PR DESCRIPTION
ignore_errors will just continue playbook execution on failure, and not actually change the task to be success. Due to a bug in Interworx, facter output is causing issues since Ansible thinks that there is a problem since something gets printed to STDERR. This is a temporary solution until a fixed release is available.