### PR TITLE
ENG-2460 fix puppet repo conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     name: "{{ puppet_repo_url }}"
     state: "present"
   register: result
-  until: 'result.rc == 0'
+  until: 'result.rc | default(1) == 0'
   retries: 5
   delay: 10
   when: not puppet_repofile_result.stat.exists


### PR DESCRIPTION
before was getting this:

```
FAILED! => {"msg": "The conditional check 'result.rc == 0' failed. The error was: error while evaluating conditional (result.rc == 0): 'dict object' has no attribute 'rc'"
```